### PR TITLE
Исправление ошибки задвоения пакетов composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,5 +85,8 @@
 		"phpunit/phpunit": "~3.7",
 		"phpunit/phpunit-selenium": "~1.4.0",
 		"phing/phing": "2.*"
+	},
+	"replace": {
+		"yiisoft/yii":"1.1.*"
 	}
 }


### PR DESCRIPTION
Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
